### PR TITLE
Fix the equal volumn expression

### DIFF
--- a/pytmatrix/tmatrix.py
+++ b/pytmatrix/tmatrix.py
@@ -251,10 +251,7 @@ class Scatterer(object):
             else: # prolate
                 r_eq = self.radius*self.axis_ratio**(2.0/3.0)
         elif self.shape == Scatterer.SHAPE_CYLINDER:
-            if self.axis_ratio > 1.0: # oblate
-                r_eq = self.radius*(1.5/self.axis_ratio)**(1.0/3.0)
-            else: # prolate
-                r_eq = self.radius*(1.5*self.axis_ratio**2)**(1.0/3.0)
+            r_eq = self.radius * (1.5*self.axis_ratio**2)**(1.0/3.0) * (self.axis_ratio**2 + 1)**(-1.0/2.0)
         else:
             raise AttributeError("Unsupported shape for maximum radius.")
         return r_eq


### PR DESCRIPTION
THE EXPRESSION FOR EQUAL VOLUMN RADIUS IS WRONG!!!
I have compared the results with ADDA computations
fix the equal volumn expression for prolate spheroid and cylinder